### PR TITLE
Avoid calling `update_playlist_detail` twice in `NetEaseAPI.get_playlist_detail`

### DIFF
--- a/feeluown/plugin/NetEaseMusic/normalize.py
+++ b/feeluown/plugin/NetEaseMusic/normalize.py
@@ -170,12 +170,13 @@ class NetEaseAPI(object):
     # TODO: change param 'cache' name to others
     def get_playlist_detail(self, pid, cache=True):
         '''update playlist detail in sqlite if cache is false'''
-        if cache is False:
-            app_event_loop = asyncio.get_event_loop()
-            app_event_loop.run_in_executor(
-                None, partial(self.update_playlist_detail, pid))
 
         if PlaylistDb.exists(pid):
+            if cache is False:
+                app_event_loop = asyncio.get_event_loop()
+                app_event_loop.run_in_executor(
+                    None, partial(self.update_playlist_detail, pid))
+
             LOG.info("Read playlist %d info from sqlite" % (pid))
             return PlaylistDb.get_data(pid)
         else:


### PR DESCRIPTION
点击一个没有被缓存过的歌单会导致程序崩溃，错误信息如下：

```
Traceback (most recent call last):
  File "../feeluown/view_api.py", line 199, in on_playlist_btn_clicked
    pid, cache=False)
  File "../feeluown/plugin/NetEaseMusic/normalize.py", line 182, in get_playlist_detail
    return self.update_playlist_detail(pid)
  File "../feeluown/plugin/NetEaseMusic/normalize.py", line 161, in update_playlist_detail
    if PlaylistDb.exists(pid):
  File "../feeluown/plugin/NetEaseMusic/model.py", line 42, in exists
    if ControllerApi.session.query(cls).filter(cls.pid==pid).count() > 0:
  File "/usr/lib/python3.5/site-packages/sqlalchemy/orm/query.py", line 2955, in count
    return self.from_self(col).scalar()
  File "/usr/lib/python3.5/site-packages/sqlalchemy/orm/query.py", line 2724, in scalar
    ret = self.one()
  File "/usr/lib/python3.5/site-packages/sqlalchemy/orm/query.py", line 2693, in one
    ret = list(self)
  File "/usr/lib/python3.5/site-packages/sqlalchemy/orm/query.py", line 2736, in __iter__
    return self._execute_and_instances(context)
  File "/usr/lib/python3.5/site-packages/sqlalchemy/orm/query.py", line 2749, in _execute_and_instances
    close_with_result=True)
  File "/usr/lib/python3.5/site-packages/sqlalchemy/orm/query.py", line 2740, in _connection_from_session
    **kw)
  File "/usr/lib/python3.5/site-packages/sqlalchemy/orm/session.py", line 905, in connection
    execution_options=execution_options)
  File "/usr/lib/python3.5/site-packages/sqlalchemy/orm/session.py", line 910, in _connection_for_bind
    engine, execution_options)
  File "/usr/lib/python3.5/site-packages/sqlalchemy/orm/session.py", line 313, in _connection_for_bind
    self._assert_active()
  File "/usr/lib/python3.5/site-packages/sqlalchemy/orm/session.py", line 202, in _assert_active
    "This session is in 'prepared' state; no further "
sqlalchemy.exc.InvalidRequestError: This session is in 'prepared' state; no further SQL can be emitted within this transaction.
/usr/bin/FeelUOwn: line 2: 19582 Aborted                 (core dumped) python /usr/share/feeluown-git/feeluown/main.py $*
```

查看代码发现在 `NetEaseAPI.get_playlist_detail()` 方法中，如果 参数 `cache` 为 `False` 且 `PlaylistDb.exists(pid)` 返回 `False` 时，会造成调用了 `update_playlist_detail()` 方法两次。