### PR TITLE
修复一个 bug

### DIFF
--- a/feeluown/app.py
+++ b/feeluown/app.py
@@ -67,6 +67,7 @@ class App(FFrame):
         self.request.connected_signal.connect(self._on_network_connected)
         self.request.disconnected_signal.connect(self._on_network_disconnected)
         self.request.slow_signal.connect(self._on_network_slow)
+        self.request.server_error.connect(self._on_network_server_error)
 
         top_panel.pc_panel.volume_slider.sliderMoved.connect(
             self.change_volume)
@@ -138,14 +139,19 @@ class App(FFrame):
 
     def _on_network_slow(self):
         network_status_label = self.ui.status_panel.network_status_label
+        self.message('网络连接超时', error=True)
         network_status_label.set_state(0)
 
     def _on_network_connected(self):
         network_status_label = self.ui.status_panel.network_status_label
         network_status_label.set_state(1)
 
+    def _on_network_server_error(self):
+        self.message('服务端出现错误', error=True)
+
     def _on_network_disconnected(self):
         network_status_label = self.ui.status_panel.network_status_label
+        self.message('网络连接失败', error=True)
         network_status_label.set_state(0)
 
     def change_volume(self, value):

--- a/feeluown/app.py
+++ b/feeluown/app.py
@@ -67,7 +67,7 @@ class App(FFrame):
         self.request.connected_signal.connect(self._on_network_connected)
         self.request.disconnected_signal.connect(self._on_network_disconnected)
         self.request.slow_signal.connect(self._on_network_slow)
-        self.request.server_error.connect(self._on_network_server_error)
+        self.request.server_error_signal.connect(self._on_network_server_error)
 
         top_panel.pc_panel.volume_slider.sliderMoved.connect(
             self.change_volume)

--- a/feeluown/request.py
+++ b/feeluown/request.py
@@ -8,6 +8,7 @@ class Request(QObject):
     connected_signal = pyqtSignal()
     disconnected_signal = pyqtSignal()
     slow_signal = pyqtSignal()
+    server_error = pyqtSignal()
 
     def __init__(self, app):
         super().__init__(parent=app)
@@ -19,12 +20,10 @@ class Request(QObject):
             self.connected_signal.emit()
             return res
         except ConnectionError:
-            self._app.message('网络连接失败', error=True)
             self.disconnected_signal.emit()
         except HTTPError:
             self._app.message('服务端出现错误', error=True)
         except Timeout:
-            self._app.message('网络连接超时', error=True)
             self.slow_signal.emit()
         return None
 

--- a/feeluown/request.py
+++ b/feeluown/request.py
@@ -8,7 +8,7 @@ class Request(QObject):
     connected_signal = pyqtSignal()
     disconnected_signal = pyqtSignal()
     slow_signal = pyqtSignal()
-    server_error = pyqtSignal()
+    server_error_signal = pyqtSignal()
 
     def __init__(self, app):
         super().__init__(parent=app)
@@ -22,7 +22,7 @@ class Request(QObject):
         except ConnectionError:
             self.disconnected_signal.emit()
         except HTTPError:
-            self._app.message('服务端出现错误', error=True)
+            self.server_error_signal.emit()
         except Timeout:
             self.slow_signal.emit()
         return None
@@ -32,9 +32,9 @@ class Request(QObject):
             res = requests.post(*args, **kw)
             return res
         except ConnectionError:
-            self._app.message('网络连接失败', error=True)
+            self.disconnected_signal.emit()
         except HTTPError:
-            self._app.message('服务端出现错误', error=True)
+            self.server_error_signal.emit()
         except Timeout:
-            self._app.message('网络连接超时', error=True)
+            self.slow_signal.emit()
         return None


### PR DESCRIPTION
# bug

当断网的情况下打开 `FeelUOwn`，窗口下方显示 `网络连接错误`; 此时连接网络进行登录，窗口下方仍然显示 `网络连接错误`，而不会消失。

经过调试知道，打开断网的情况下，`Request` 的 `get` 方法调用的 `self._app.message()` 方法下，`get_event_loop` 失败。

```python
    def get_event_loop(self):
        """Get the event loop.

        This may be None or an instance of EventLoop.
        """
        if (self._local._loop is None and
            not self._local._set_called and
            isinstance(threading.current_thread(), threading._MainThread)):
            self.set_event_loop(self.new_event_loop())
        if self._local._loop is None:
            raise RuntimeError('There is no current event loop in thread %r.'
                               % threading.current_thread().name)
        return self._local._loop
```

原因在于Request.get抛出异常的情况下，当前的线程不是`threading._MainThread`，导致 `get_event_loop` 调用失败。

# 修复

`MessageLabel` 类的 `show_message` 用到了 `asyncio` 和 `消息队列`，主要实现异步显示消息文本，并且每个消息的显示滞留时间是 `3 秒`，最后队列为空，即没有任何消息要显示，则隐藏 `MessageLabel` 。

为了解决 `show_message` 在 Request.get抛出异常的情况下，线程问题，可以将 `ConnectionError` 消息的发送，转移到 `App._on_network_disconnected`,然后由相应的信号槽负责调用，且不破坏程序结构逻辑

增加了 相应的 `Request.server_error_signal成员` 和 `App._on_network_server_error方法` 以及 信号的连接

希望采纳！