### PR TITLE
fix: __main__ module can't use Relative Imports

### DIFF
--- a/feeluown/__main__.py
+++ b/feeluown/__main__.py
@@ -4,13 +4,16 @@ import asyncio
 import os
 import sys
 
+if __name__ == '__main__':
+   sys.path.append(os.path.dirname(sys.path[0]))
+
 from PyQt5.QtWidgets import QApplication
 from quamash import QEventLoop
 
-from .app import App
-from .consts import HOME_DIR, USER_PLUGINS_DIR, PLUGINS_DIR, DATA_DIR,\
+from feeluown.app import App
+from feeluown.consts import HOME_DIR, USER_PLUGINS_DIR, PLUGINS_DIR, DATA_DIR,\
     CACHE_DIR, USER_THEMES_DIR
-from .config import config
+from feeluown.config import config
 from feeluown import logger_config
 
 


### PR DESCRIPTION
# 缺陷：\_\_mian\_\_模块不能使用相对导入

[PEP 328 Relative Imports and __name__](https://www.python.org/dev/peps/pep-0328/#relative-imports-and-name)  ，相对导入在 package 分层中，使用模块的__name__ 属性得到模块的位置。但是如果模块的名字没有包含任何 package 信息（例如，__main__模块），相对导入会被当作顶层模块导入（a top level module），不管是否该模块实际位于文件系统。

# 修复

根据 [6.4.2. Intra-package References](https://docs.python.org/3/tutorial/modules.html#intra-package-references) 的建议：

> Note that relative imports are based on the name of the current module.  Since the name of the main module is always "__main__", modules intended for use as the main module of a Python application must always use absolute imports.

__mian__ 使用 `绝对导入` 方式，而其他模块仍使用 `相对导入`

# 后话

## 导入的方式

参考 [stackoverflow](http://stackoverflow.com/questions/16981921/relative-imports-in-python-3)  **vaultah** 的回答

## 为什么选择相对导入

[PEP 328 Rationale for Relative Imports] ，相对导入可以对大型的 python packages 重构时，不用重新编辑 sub-packages。

希望采纳！