### PR TITLE
[WIP] feat: return json format responses

### DIFF
--- a/feeluown/server.py
+++ b/feeluown/server.py
@@ -24,6 +24,7 @@ class FuoServer:
     async def handle_conn(self, conn, addr):
         event_loop = asyncio.get_event_loop()
         await event_loop.sock_sendall(conn, b'OK feeluown 1.0.0\n')
+        output_format = "plain"
         while True:
             command = b''
             try:
@@ -45,10 +46,24 @@ class FuoServer:
             if not command:
                 conn.close()
                 break
-            logger.debug('RECV: %s', command)
-            msg = interprete(command,
-                             library=self._library,
-                             player=self._player,
-                             playlist=self._playlist,
-                             live_lyric=self._live_lyric)
+            if command.startswith("format"):
+                is_valid = True
+                if command.find("plain") != -1:
+                    output_format = "plain"
+                elif command.find("json") != -1:
+                    output_format = "json"
+                else:
+                    is_valid = False
+                if is_valid:
+                    msg = "OK output format switched to " + output_format + "\n"
+                else:
+                    msg = "Oops invalid format! output format is " + output_format + "\n"
+            else:
+                logger.debug('RECV: %s', command)
+                msg = interprete(command,
+                                 library=self._library,
+                                 player=self._player,
+                                 playlist=self._playlist,
+                                 live_lyric=self._live_lyric,
+                                 output_format=output_format)
             await event_loop.sock_sendall(conn, bytes(msg, 'utf-8'))

--- a/fuocore/cmds/__init__.py
+++ b/fuocore/cmds/__init__.py
@@ -111,7 +111,7 @@ class CmdResolver:
 cmd_resolver = CmdResolver(cmd_handler_mapping)
 
 
-def exec_cmd(cmd, *args, library, player, playlist, live_lyric):
+def exec_cmd(cmd, *args, library, player, playlist, live_lyric, output_format):
     logger.debug('EXEC_CMD: ' + str(cmd))
 
     handler_cls = cmd_resolver.get_handler(cmd.action)
@@ -130,7 +130,7 @@ def exec_cmd(cmd, *args, library, player, playlist, live_lyric):
                               player=player,
                               playlist=playlist,
                               live_lyric=live_lyric)
-        cmd_rv = handler.handle(cmd)
+        cmd_rv = handler.handle(cmd, output_format=output_format)
         if cmd_rv:
             rv += '\n' + cmd_rv
     except Exception as e:
@@ -141,11 +141,12 @@ def exec_cmd(cmd, *args, library, player, playlist, live_lyric):
         return rv + '\nOK\n'
 
 
-def interprete(text, *args, library, player, playlist, live_lyric):
+def interprete(text, *args, library, player, playlist, live_lyric, output_format="plain"):
     tokens = CmdLexer().get_tokens(text)
     cmd = CmdParser().parse(tokens)
     return exec_cmd(cmd,
                     library=library,
                     player=player,
                     playlist=playlist,
-                    live_lyric=live_lyric)
+                    live_lyric=live_lyric,
+                    output_format=output_format)

--- a/fuocore/cmds/base.py
+++ b/fuocore/cmds/base.py
@@ -24,5 +24,5 @@ class AbstractHandler(metaclass=HandlerMeta):
         self.live_lyric = live_lyric
         self.model_parser = ModelParser(library)
 
-    def handle(self, cmd):
+    def handle(self, cmd, output_format):
         raise NotImplementedError

--- a/fuocore/cmds/exec_.py
+++ b/fuocore/cmds/exec_.py
@@ -1,26 +1,44 @@
 import io
 import sys
 import traceback
+import json
 
 from .base import AbstractHandler
+from .helpers import ReturnMessage, ReturnStatus
 
 
 class ExecHandler(AbstractHandler):
     cmds = 'exec'
 
-    def handle(self, cmd):
+    def handle(self, cmd, output_format):
         code = cmd.args[0]
-        output = io.StringIO()
-        sys.stderr = output
-        sys.stdout = output
+        if output_format == "plain":
+            output = io.StringIO()
+            sys.stderr = output
+            sys.stdout = output
+        else:
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            sys.stdout = stdout
+            sys.stderr = stderr
+        
+        is_failed = False
         try:
             self.exec_(code)
         except Exception as e:
+            is_failed = True
             traceback.print_exc()
         finally:
             sys.stderr = sys.__stderr__
             sys.stdout = sys.__stdout__
-        msg = output.getvalue()
+
+        if output_format == "plain":
+            msg = output.getvalue()
+        else:
+            result = ReturnMessage(output_format=output_format)
+            result.status = ReturnStatus.fail if is_failed else ReturnStatus.success
+            result.data = {"stdout": stdout.getvalue(), "stderr": stderr.getvalue()}
+            msg = result.dumps()
         return msg
 
     def exec_(self, code):

--- a/fuocore/cmds/helpers.py
+++ b/fuocore/cmds/helpers.py
@@ -155,7 +155,7 @@ def show_song_json(song, brief=False):
     result = ReturnMessage()
 
     if brief:
-        data = dict()
+        data = {}
         data["song"] = song_uri
         data["title"] = title
         data["artists_name"] = artists_name
@@ -165,7 +165,7 @@ def show_song_json(song, brief=False):
     # XXX: 这个操作可能会产生网络请求
     album_uri = get_url(song.album)
     artists_uri = [get_url(artist) for artist in song.artists]
-    data = dict()
+    data = {}
     data["provider"] = song.source
     data["uri"] = song_uri
     data["title"] = song.title

--- a/fuocore/cmds/helpers.py
+++ b/fuocore/cmds/helpers.py
@@ -50,7 +50,6 @@ class ReturnMessage:
         self.msg = msg
         self.output_format = output_format
     def dumps(self):
-        code = RETURN_STATUS_MAP[self.status]
         msg_dict = {"status": RETURN_STATUS_MAP[self.status]}
         logger.debug(self.data)
         if self.data:
@@ -58,7 +57,7 @@ class ReturnMessage:
         if self.msg:
             msg_dict["msg"] = self.msg
         if self.output_format == "json":
-            return json.dumps({"status": code, "data": self.data, "msg": self.msg})
+            return json.dumps(msg_dict)
         else:
             return
 

--- a/fuocore/cmds/player.py
+++ b/fuocore/cmds/player.py
@@ -59,7 +59,7 @@ class PlayerHandler(AbstractHandler):
             if output_format == "plain":
                 return self.player.play(s, video=False)
             else:
-                data = dict()
+                data = {}
                 data["type"] = "http"
                 data["player"] = self.player.play(s, video=False)
                 result = ReturnMessage(data=data, output_format=output_format)
@@ -88,7 +88,7 @@ class PlayerHandler(AbstractHandler):
                     msg += 'options::\n' + '\n'.join(lines)
                 return msg
             else:
-                data = dict()
+                data = {}
                 data["selected"] = get_url(songs[0])
                 data["songs"] = list(map(get_url, songs))
                 result = ReturnMessage(data=data, output_format=output_format)

--- a/fuocore/cmds/playlist.py
+++ b/fuocore/cmds/playlist.py
@@ -6,7 +6,7 @@ from .base import AbstractHandler
 class PlaylistHandler(AbstractHandler):
     cmds = ('add', 'remove', 'list', 'next', 'previous', 'clear',)
 
-    def handle(self, cmd):
+    def handle(self, cmd, output_format):
         if cmd.action == 'add':
             return self.add(cmd.args[0].strip())
         elif cmd.action == 'remove':

--- a/fuocore/cmds/search.py
+++ b/fuocore/cmds/search.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 class SearchHandler(AbstractHandler):
     cmds = 'search'
 
-    def handle(self, cmd):
+    def handle(self, cmd, output_format):
         return self.search_songs(cmd.args[0])
 
     def search_songs(self, query):

--- a/fuocore/cmds/show.py
+++ b/fuocore/cmds/show.py
@@ -15,7 +15,7 @@ from fuocore.router import Router
 
 from .base import AbstractHandler
 from .helpers import (
-    show_song, show_artist, show_album, show_user,
+    show_song, show_song_json, show_artist, show_album, show_user,
     show_playlist
 )
 
@@ -29,7 +29,7 @@ route = router.route
 class ShowHandler(AbstractHandler):
     cmds = 'show'
 
-    def handle(self, cmd):
+    def handle(self, cmd, output_format):
         if cmd.args:
             furi = cmd.args[0]
         else:
@@ -37,7 +37,7 @@ class ShowHandler(AbstractHandler):
         r = urlparse(furi)
         path = '/{}{}'.format(r.netloc, r.path)
         logger.debug('请求 path: {}'.format(path))
-        rv = router.dispatch(path, {'library': self.library})
+        rv = router.dispatch(path, {'library': self.library, 'output_format': output_format})
         return rv
 
 
@@ -53,7 +53,11 @@ def song_detail(req, provider, sid):
     provider = req.ctx['library'].get(provider)
     song = provider.Song.get(sid)
     if song is not None:
-        return show_song(song)
+        output_format = req.ctx['output_format']
+        if output_format == "plain":
+            return show_song(song)
+        else:
+            return show_song_json(song)
 
 
 @route('/<provider>/songs/<sid>/lyric')

--- a/fuocore/cmds/status.py
+++ b/fuocore/cmds/status.py
@@ -7,7 +7,7 @@ from .helpers import show_song
 class StatusHandler(AbstractHandler):
     cmds = 'status'
 
-    def handle(self, cmd):
+    def handle(self, cmd, output_format):
         player = self.player
         playlist = self.playlist
         live_lyric = self.live_lyric

--- a/fuocore/lyric.py
+++ b/fuocore/lyric.py
@@ -10,7 +10,7 @@ def parse(content):
     >>> parse("[00:00.00] 作曲 : 周杰伦\\n[00:01.00] 作词 : 周杰伦\\n")
     {0.0: ' 作曲 : 周杰伦', 1000.0: ' 作词 : 周杰伦'}
     """
-    ms_sentence_map = dict()
+    ms_sentence_map = {}
     sentence_pattern = re.compile(r'\[(\d+(:\d+){0,2}(\.\d+)?)\]')
     lines = content.splitlines()
     for line in lines:


### PR DESCRIPTION
## 概述
尝试给 tcp 服务添加 json 返回选项
## 协议
```
nc> format [json|plain]
OK output format switched to [json|plain]
```
## json 格式
``` json
{
  "status": "success/fail/error",
  "data": {},
  "msg": ""
}
```
## 需要帮助
*WIP* 暂时只完成了部分 API 的改写，本人时间不足，可能无法及时完成全部改写。Help needed.
*RFC* 协议部分实现得比较粗糙，可能需要修改。
