### PR TITLE
fix(fuocore): fetch display fields on demand when not inited before

### DIFF
--- a/fuocore/models.py
+++ b/fuocore/models.py
@@ -287,7 +287,7 @@ class BaseModel(Model):
         if not isinstance(other, BaseModel):
             return False
         return all([other.source == self.source,
-                    other.identifier == self.identifier,
+                    str(other.identifier) == str(self.identifier),
                     other.meta.model_type == self.meta.model_type])
 
     def __getattribute__(self, name):
@@ -554,7 +554,7 @@ class SongModel(BaseModel):
         if not isinstance(other, SongModel):
             return False
         return all([other.source == self.source,
-                    other.identifier == self.identifier])
+                    str(other.identifier) == str(self.identifier)])
 
 
 class PlaylistModel(BaseModel):

--- a/fuocore/models.py
+++ b/fuocore/models.py
@@ -303,7 +303,7 @@ class BaseModel(Model):
         if name in ('identifier', 'meta', '_meta', 'stage', 'exists'):
             return value
 
-        if name in cls.meta.fields \
+        if (name in cls.meta.fields or name.replace("_display", "") in cls.meta.fields_display) \
            and name not in cls.meta.fields_no_get \
            and value is None \
            and cls.meta.allow_get \

--- a/fuocore/protocol/model_parser.py
+++ b/fuocore/protocol/model_parser.py
@@ -88,7 +88,8 @@ class ModelParser:
     def parse_song_desc(cls, desc):
         values = desc.split(' - ')
         if len(values) < 4:
-            values.extend([''] * (4 - len(values)))
+            values = values if values != [''] else [None]
+            values.extend([None] * (4 - len(values)))
         return {
             'title': values[0],
             'artists_name': values[1],


### PR DESCRIPTION
> fuo play fuo://...
> fuo status

If this song is already in the playlist, its meta data are broken due to improperly handled display fields.
This commit fixes this problem. Although unit tests have passed so far, I changed some attributes' default values from '' to None, which may lead to inconsistent behaviors. Till now, I haven't seen any unexpected behavior, but more observation may be needed.