### PR TITLE
feat: song mutliple quality support

### DIFF
--- a/docs/source/coding_style.rst
+++ b/docs/source/coding_style.rst
@@ -23,7 +23,10 @@
 - fuocore 包相关代码都应该添加相应测试
 
 
-yixi
+特殊风格
+-----------
+
+- 标记了 alpha 的函数和类，它们的设计都是不确定的，外部应该尽少依赖
 
 
 .. _Sphinx docstring format: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html#the-sphinx-docstring-format

--- a/feeluown/player.py
+++ b/feeluown/player.py
@@ -27,7 +27,9 @@ class Playlist(_Playlist):
     @_Playlist.current_song.setter
     def current_song(self, song):
         """如果歌曲 url 无效，则尝试从其它平台找一个替代品"""
-        if song is None or song.url:
+        if song is None or \
+           (song.meta.support_multi_quality and song.list_quality()) or \
+           song.url:
             _Playlist.current_song.fset(self, song)
             return
         self.mark_as_bad(song)

--- a/feeluown/ui.py
+++ b/feeluown/ui.py
@@ -15,7 +15,6 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
 )
 
-from fuocore.models import Media
 from fuocore.player import PlaybackMode, State
 from fuocore.utils import parse_ms
 
@@ -491,7 +490,7 @@ class Ui:
 
     def _play_mv(self):
         song = self._app.player.current_song
-        url = song.mv.media.select_url(Media.Q.sq)
+        url, _ = song.mv.select_url()
         self._app.player.play(url)
         self.show_video_widget()
 

--- a/fuocore/__init__.py
+++ b/fuocore/__init__.py
@@ -1,10 +1,11 @@
 from fuocore.models import ModelType  # noqa
 from fuocore.player import (
-    MpvPlayer,
     State as PlayerState,
     PlaybackMode,
     Playlist,
 )  # noqa
+# FIXME: remove this when no one import MpvPlayer from here
+from fuocore.mpvplayer import MpvPlayer  # noqa
 from fuocore.live_lyric import LiveLyric  # noqa
 from .library import Library  # noqa
 

--- a/fuocore/media.py
+++ b/fuocore/media.py
@@ -1,0 +1,161 @@
+import re
+from enum import Enum
+
+
+class Quality:
+    """
+
+    >>> [Quality.Audio.best(), Quality.Audio.worst()]
+    [<Audio.shq: 'shq'>, <Audio.lq: 'lq'>]
+    >>> Quality.SortPolicy.apply('hq><', ['shq', 'hq', 'sq', 'lq'])
+    ['hq', 'sq', 'shq', 'lq']
+    """
+
+    class SortPolicy:
+        rules = (
+            ('rlrl', r'(\w+)><'),
+            ('lrlr', r'(\w+)<>'),
+            ('llr', r'(\w+)<<>'),
+            ('rrl', r'(\w+)>><'),
+            ('rrr', r'(\w+)?>>>'),
+            ('lll', r'(\w+)?<<<'),
+        )
+
+        @classmethod
+        def apply(cls, source, l):
+            """sort the list L using the policy parsed from SOURCE
+
+            :param source: policy source string
+            :param l: quality value list
+            :return: sorted quality value list
+            :raise ValueError: policy source string is invalid
+
+            For example, when the l is: [hp, h, s, l]
+
+            h<<> = h -> hp -> s  -> l
+            h>>> = h -> s  -> l  -> hp
+            h><  = h -> s  -> hp -> l
+            h<>  = h -> hp -> s  -> l
+            >>>  = hp -> h -> s  -> l    # doctest: +SKIP
+            <<<  = l -> s -> h -> hp
+            """
+            rule, q = cls._parse(source)
+            if rule in ('rrr', 'lll'):
+                return l if rule == 'rrr' else l[::-1]
+            q_idx = cls._get_index(q, l)
+            new_l = [q]
+            left = l[:q_idx][::-1]
+            right = l[q_idx+1:]
+            if rule == 'rrl':
+                new_l = right + new_l + left
+            elif rule == 'llr':
+                new_l = left + new_l + right
+            elif rule == 'rlrl':
+                new_l += cls._cross_merge_list(right, left)
+            else:  # rule == 'lrlr'
+                new_l += cls._cross_merge_list(left, right)
+            return new_l
+
+        @classmethod
+        def _parse(cls, source):
+            """extract a policy oject from the policy string
+
+            temporarily, the policy object is a tuple, e.g., ('rlrl', 'hq').
+            """
+            for name, p in cls.rules:
+                regex = re.compile(p)
+                m = regex.match(source)
+                if m is not None:
+                    return name, m.group(1)
+            raise ValueError('invalid policy string: rule not found')
+
+        @staticmethod
+        def _cross_merge_list(l1, l2):
+            """
+            >>> Quality.SortPolicy._cross_merge_list([1, 2], [3])
+            [1, 3, 2]
+            >>> Quality.SortPolicy._cross_merge_list([3], [1, 2])
+            [3, 1, 2]
+            """
+            i = 0
+            l = []  # noqa: E741
+            while i < len(l1) and i < len(l2):
+                l.append(l1[i])
+                l.append(l2[i])
+                i += 1
+            if i < len(l1):
+                l += l1[i:]  # noqa: E741
+            if i < len(l2):
+                l += l2[i:]  # noqa: E741
+            return l
+
+        @staticmethod
+        def _get_index(q, l):
+            try:
+                q_idx = l.index(q)
+            except ValueError:
+                raise ValueError('invalid policy string: quality not found')
+            return q_idx
+
+    class Mixin:
+        @classmethod
+        def best(cls):
+            return list(cls)[0]
+
+        @classmethod
+        def worst(cls):
+            return list(cls)[-1]
+
+    class Audio(Mixin, Enum):
+        shq = 'shq'  #: super high quality(>=320kbps)
+        hq = 'hq'    #: high quality
+        sq = 'sq'    #: standard quality
+        lq = 'lq'    #: low quality
+
+    class Video(Mixin, Enum):
+        fhd = 'fhd'  #: full high definition
+        hd = 'hd'    #: high definition
+        sd = 'sd'    #: standard definition
+        ld = 'ld'    #: low definition
+
+
+class MultiQualityMixin:
+    def list_quality(self):
+        """list available quality"""
+
+    def select_url(self, policy=None):
+        """select a url by quality(and fallback policy)
+
+        :param policy: fallback priority/policy
+        """
+        # fetch available quality list
+        available_q_set = set(self.list_quality())
+        if not available_q_set:
+            return None, None
+
+        QualityCls = self.QualityCls
+        # translate policy into quality priority list
+        if policy is None:
+            if QualityCls == Quality.Audio:
+                policy = 'hq<>'
+            else:  # Quality.Video
+                policy = 'hd<>'
+        sorted_q_list = Quality.SortPolicy.apply(
+            policy, [each.value for each in list(QualityCls)])
+
+        # find the first available quality
+        for quality in sorted_q_list:
+            if quality in available_q_set:
+                break
+        return self.get_url(quality), quality
+
+    def get_url(self, quality):
+        """get url by quality
+
+        if q is not available, return None.
+        """
+
+
+class Media:
+    def __init__(self, url):
+        self.url = url

--- a/fuocore/models.py
+++ b/fuocore/models.py
@@ -334,9 +334,12 @@ class LyricModel(BaseModel):
         fields = ['song', 'content', 'trans_content']
 
 
-class MvModel(BaseModel):
+class MvModel(BaseModel, MultiQualityMixin):
+    QualityCls = Quality.Video
+
     class Meta:
         fields = ['name', 'media', 'desc', 'cover', 'artist']
+        support_multi_quality = False
 
 
 class SongModel(BaseModel, MultiQualityMixin):

--- a/fuocore/models.py
+++ b/fuocore/models.py
@@ -286,6 +286,60 @@ class BaseModel(Model):
         """Model batch get method"""
 
 
+class Media:
+    """(alpha) physical media resource for song/mv"""
+
+    class Q(IntEnum):  # Quality
+        #: lossless for audio, 1080p+ for video
+        sq = 16
+        #: about 200kpbs for audio, 720p for video
+        hd = 8
+        #: about 100kpbs for audio, 480p for video
+        sd = 4
+        ld = 2
+
+        @classmethod
+        def list(cls):
+            # desc ordering
+            return [cls.sq, cls.hd, cls.sd, cls.ld]
+
+    class S(IntEnum):
+        updown = 0
+        downup = 1
+
+
+class MultiQualityMixin:
+
+    def list_q(self):
+        """list available quality"""
+
+    def select_url(self, q, s=Media.S.updown):
+        """select a url by quality and fallback strategy
+
+        :param q: quality
+        :param s: fallback strategy
+        """
+        S = Media.S
+        q_l = self.list_q()
+        if not q_l:
+            return None
+        q_ordered = sorted(q_l, reverse=(s == S.downup))
+        target_q = q_ordered[0]
+        for _q in q_ordered:
+            if _q == q or \
+               (s == S.downup and _q < q) or \
+               (s == S.updown and _q > q):
+                target_q = _q
+                break
+        return self.get_url(target_q)
+
+    def get_url(self, q):
+        """get url by quality
+
+        if q is not available, return None.
+        """
+
+
 class ArtistModel(BaseModel):
     """Artist Model"""
 
@@ -332,57 +386,6 @@ class LyricModel(BaseModel):
         fields = ['song', 'content', 'trans_content']
 
 
-class Media:
-    """physical media resource for song/mv"""
-
-    class Q(IntEnum):  # Quality
-        #: lossless for audio, 1080p+ for video
-        sq = 16
-        #: about 200kpbs for audio, 720p for video
-        hd = 8
-        #: about 100kpbs for audio, 480p for video
-        sd = 4
-        ld = 2
-
-        @classmethod
-        def list(cls):
-            # desc ordering
-            return [cls.sq, cls.hd, cls.sd, cls.ld]
-
-    class S(IntEnum):
-        updown = 0
-        downup = 1
-
-    def list_q(self):
-        """list available quality"""
-
-    def select_url(self, q, s=S.updown):
-        """select a url by quality and fallback strategy
-
-        :param q: quality
-        :param s: fallback strategy
-        """
-        S = Media.S
-        q_l = self.list_q()
-        if not q_l:
-            return None
-        q_ordered = sorted(q_l, reverse=(s == S.downup))
-        target_q = q_ordered[0]
-        for _q in q_ordered:
-            if _q == q or \
-               (s == S.downup and _q < q) or \
-               (s == S.updown and _q > q):
-                target_q = _q
-                break
-        return self.get_url(target_q)
-
-    def get_url(self, q):
-        """get url by quality
-
-        if q is not available, return None.
-        """
-
-
 class MvModel(BaseModel):
     class Meta:
         fields = ['name', 'media', 'desc', 'cover', 'artist']
@@ -391,10 +394,11 @@ class MvModel(BaseModel):
 class SongModel(BaseModel):
     class Meta:
         model_type = ModelType.song.value
-        # TODO: 支持低/中/高不同质量的音乐文件
         fields = ['album', 'artists', 'lyric', 'comments', 'title', 'url',
                   'duration', 'mv', 'media']
         fields_display = ['title', 'artists_name', 'album_name', 'duration_ms']
+
+        support_multi_quality = False
 
     @property
     def artists_name(self):

--- a/fuocore/mpvplayer.py
+++ b/fuocore/mpvplayer.py
@@ -1,0 +1,226 @@
+import locale
+import logging
+
+from mpv import (
+    MPV,
+    MpvEventID,
+    MpvEventEndFile,
+    _mpv_set_property_string,
+)
+
+from fuocore.dispatch import Signal
+from fuocore.media import Media
+from fuocore.player import AbstractPlayer, State, PlaybackMode
+
+
+logger = logging.getLogger(__name__)
+
+
+class MpvPlayer(AbstractPlayer):
+    """
+
+    player will always play playlist current song. player will listening to
+    playlist ``song_changed`` signal and change the current playback.
+
+    TODO: make me singleton
+    """
+    def __init__(self, audio_device=b'auto', winid=None, *args, **kwargs):
+        super(MpvPlayer, self).__init__(*args, **kwargs)
+        # https://github.com/cosven/FeelUOwn/issues/246
+        locale.setlocale(locale.LC_NUMERIC, 'C')
+        mpvkwargs = {}
+        if winid is not None:
+            mpvkwargs['wid'] = winid
+        mpvkwargs['vo'] = 'opengl-cb'
+        # set log_handler if you want to debug
+        # mpvkwargs['log_handler'] = self.__log_handler
+        # mpvkwargs['msg_level'] = 'all=v'
+        self._mpv = MPV(ytdl=True,
+                        input_default_bindings=True,
+                        input_vo_keyboard=True,
+                        **mpvkwargs)
+        _mpv_set_property_string(self._mpv.handle, b'audio-device', audio_device)
+
+        # TODO: 之后可以考虑将这个属性加入到 AbstractPlayer 中
+        self.video_format_changed = Signal()
+
+    def initialize(self):
+        self._mpv.observe_property(
+            'time-pos',
+            lambda name, position: self._on_position_changed(position)
+        )
+        self._mpv.observe_property(
+            'duration',
+            lambda name, duration: self._on_duration_changed(duration)
+        )
+        self._mpv.observe_property(
+            'video-format',
+            lambda name, vformat: self._on_video_format_changed(vformat)
+        )
+        # self._mpv.register_event_callback(lambda event: self._on_event(event))
+        self._mpv._event_callbacks.append(self._on_event)
+        self._playlist.song_changed.connect(self._on_song_changed)
+        self.song_finished.connect(self._on_song_finished)
+        logger.info('Player initialize finished.')
+
+    def shutdown(self):
+        self._mpv.terminate()
+
+    def play(self, media, video=True):
+        # NOTE - API DESGIN: we should return None, see
+        # QMediaPlayer API reference for more details.
+
+        logger.debug("Player will play: '%s'", media)
+
+        if video:
+            # FIXME: for some property, we need to set via setattr, however,
+            #  some need to be set via _mpv_set_property_string
+            self._mpv.handle.vid = b'auto'
+            # it seems that ytdl will auto choose the default format
+            #  if we set ytdl-format to ''
+            _mpv_set_property_string(self._mpv.handle, b'ytdl-format', b'')
+        else:
+            # set vid to no and ytdl-format to bestaudio/best
+            # see https://mpv.io/manual/stable/#options-vid for more details
+            self._mpv.handle.vid = b'no'
+            _mpv_set_property_string(self._mpv.handle, b'ytdl-format', b'bestaudio/best')
+
+        if isinstance(media, Media):
+            media = media
+        else:  # media is a url
+            media = Media(media)
+        url = media.url
+
+        # Clear playlist before play next song,
+        # otherwise, mpv will seek to the last position and play.
+        self._mpv.playlist_clear()
+        self._mpv.play(url)
+        self._mpv.pause = False
+        self.state = State.playing
+        self._current_media = media
+        # TODO: we will emit a media object
+        self.media_changed.emit(media)
+
+    def play_song(self, song):
+        """播放指定歌曲
+
+        如果目标歌曲与当前歌曲不相同，则修改播放列表当前歌曲，
+        播放列表会发出 song_changed 信号，player 监听到信号后调用 play 方法，
+        到那时才会真正的播放新的歌曲。如果和当前播放歌曲相同，则忽略。
+
+        .. note::
+
+            调用方不应该直接调用 playlist.current_song = song 来切换歌曲
+        """
+        if song is not None and song == self.current_song:
+            logger.warning('The song is already under playing.')
+        else:
+            self._playlist.current_song = song
+
+    def play_next(self):
+        """播放下一首歌曲
+
+        .. note::
+
+            这里不能使用 ``play_song(playlist.next_song)`` 方法来切换歌曲，
+            ``play_song`` 和 ``playlist.current_song = song`` 是有区别的。
+        """
+        self.playlist.current_song = self.playlist.next_song
+
+    def play_previous(self):
+        self.playlist.current_song = self.playlist.previous_song
+
+    def replay(self):
+        self.playlist.current_song = self.current_song
+
+    def resume(self):
+        self._mpv.pause = False
+        self.state = State.playing
+
+    def pause(self):
+        self._mpv.pause = True
+        self.state = State.paused
+
+    def toggle(self):
+        self._mpv.pause = not self._mpv.pause
+        if self._mpv.pause:
+            self.state = State.paused
+        else:
+            self.state = State.playing
+
+    def stop(self):
+        self._mpv.pause = True
+        self.state = State.stopped
+        self._current_media = None
+        self._mpv.playlist_clear()
+        logger.info('Player stopped.')
+
+    @property
+    def position(self):
+        return self._position
+
+    @position.setter
+    def position(self, position):
+        self._mpv.seek(position, reference='absolute')
+        self._position = position
+
+    @AbstractPlayer.volume.setter
+    def volume(self, value):
+        super(MpvPlayer, MpvPlayer).volume.__set__(self, value)
+        self._mpv.volume = self.volume
+
+    @property
+    def video_format(self):
+        self._video_format
+
+    @video_format.setter
+    def video_format(self, vformat):
+        self._video_format = vformat
+        self.video_format_changed.emit(vformat)
+
+    def _on_position_changed(self, position):
+        self._position = position
+        self.position_changed.emit(position)
+
+    def _on_duration_changed(self, duration):
+        """listening to mpv duration change event"""
+        logger.debug('Player receive duration changed signal')
+        self.duration = duration
+
+    def _on_video_format_changed(self, vformat):
+        self.video_format = vformat
+
+    def _on_song_changed(self, song):
+        """播放列表 current_song 发生变化后的回调
+
+        判断变化后的歌曲是否有效的，有效则播放，否则将它标记为无效歌曲。
+        如果变化后的歌曲是 None，则停止播放。
+        """
+        if song is not None:
+            if song.meta.support_multi_quality:
+                url, quality = song.select_url('hq<>')
+            else:
+                url = song.url
+            if url:
+                self.play(url)
+            else:
+                self._playlist.mark_as_bad(song)
+                self.play_next()
+        else:
+            self.stop()
+
+    def _on_event(self, event):
+        if event['event_id'] == MpvEventID.END_FILE:
+            reason = event['event']['reason']
+            logger.debug('Current song finished. reason: %d' % reason)
+            if self.state != State.stopped and reason != MpvEventEndFile.ABORTED:
+                self.song_finished.emit()
+
+    def _on_song_finished(self):
+        if self._playlist.playback_mode == PlaybackMode.one_loop:
+            self.replay()
+        else:
+            self.play_next()
+
+    def __log_handler(self, loglevel, component, message):
+        print('[{}] {}: {}'.format(loglevel, component, message))

--- a/fuocore/player.py
+++ b/fuocore/player.py
@@ -4,19 +4,35 @@
 fuocore.player
 --------------
 
-This module difines :class:`.AbstractPlayer` ，and implement a :class:`.MpvPlayer`
+This module defines :class:`.AbstractPlayer` ，and implement a :class:`.MpvPlayer`
 based on mpv. In addition, it defines :class:`.Playlist` class, which is used
 by the player to manage playlist.
- """
+
+what happend when a song is played::
+
+    Playlist                                         MpvPlayer
+
+        current_song.setter ---[song_changed]---> play
+           ^                                      |
+           |                                      |
+           |<- play_song                          |
+           |<- play_next/play_previous            |
+           |<- play_next <-|                      |
+           |<- replay    <-| mode==one_loop       |
+                           |                      v
+                           |                    play ---[media_changed]--->
+                     [song_finished]
+                           |
+                           |
+                           ---- event(END_FILE)
+
+                                                     libmpv
+"""
 
 from abc import ABCMeta, abstractmethod
 from enum import IntEnum
-import locale
 import logging
 import random
-
-from mpv import MPV, MpvEventID, MpvEventEndFile, \
-        _mpv_set_property_string
 
 from fuocore.dispatch import Signal
 
@@ -71,9 +87,12 @@ class Playlist(object):
 
         #: playback mode changed signal
         self.playback_mode_changed = Signal()
-
-        #: current song changed signal
         self.song_changed = Signal()
+        """current song changed signal
+
+        The player will play the song after it receive the signal,
+        when song is None, the player will stop playback.
+        """
 
     def __len__(self):
         return len(self._songs)
@@ -261,7 +280,7 @@ class AbstractPlayer(metaclass=ABCMeta):
         self._state = State.stopped
         self._duration = None
 
-        self._current_url = None
+        self._current_media = None
 
         #: player position changed signal
         self.position_changed = Signal()
@@ -275,7 +294,7 @@ class AbstractPlayer(metaclass=ABCMeta):
         #: duration changed signal
         self.duration_changed = Signal()
 
-        #: media change signal
+        #: media changed signal
         self.media_changed = Signal()
 
     @property
@@ -297,8 +316,8 @@ class AbstractPlayer(metaclass=ABCMeta):
         self.state_changed.emit(value)
 
     @property
-    def current_url(self):
-        return self._current_url
+    def current_media(self):
+        return self._current_media
 
     @property
     def current_song(self):
@@ -389,200 +408,5 @@ class AbstractPlayer(metaclass=ABCMeta):
         """shutdown player, do some clean up here"""
 
 
-class MpvPlayer(AbstractPlayer):
-    """
-
-    player will always play playlist current song. player will listening to
-    playlist ``song_changed`` signal and change the current playback.
-
-    TODO: make me singleton
-    """
-    def __init__(self, audio_device=b'auto', winid=None, *args, **kwargs):
-        super(MpvPlayer, self).__init__(*args, **kwargs)
-        # https://github.com/cosven/FeelUOwn/issues/246
-        locale.setlocale(locale.LC_NUMERIC, 'C')
-        mpvkwargs = {}
-        if winid is not None:
-            mpvkwargs['wid'] = winid
-        mpvkwargs['vo'] = 'opengl-cb'
-        # set log_handler if you want to debug
-        # mpvkwargs['log_handler'] = self.__log_handler
-        # mpvkwargs['msg_level'] = 'all=v'
-        self._mpv = MPV(ytdl=True,
-                        input_default_bindings=True,
-                        input_vo_keyboard=True,
-                        **mpvkwargs)
-        _mpv_set_property_string(self._mpv.handle, b'audio-device', audio_device)
-
-        # TODO: 之后可以考虑将这个属性加入到 AbstractPlayer 中
-        self.video_format_changed = Signal()
-
-    def initialize(self):
-        self._mpv.observe_property(
-            'time-pos',
-            lambda name, position: self._on_position_changed(position)
-        )
-        self._mpv.observe_property(
-            'duration',
-            lambda name, duration: self._on_duration_changed(duration)
-        )
-        self._mpv.observe_property(
-            'video-format',
-            lambda name, vformat: self._on_video_format_changed(vformat)
-        )
-        # self._mpv.register_event_callback(lambda event: self._on_event(event))
-        self._mpv._event_callbacks.append(self._on_event)
-        self._playlist.song_changed.connect(self._on_song_changed)
-        self.song_finished.connect(self._on_song_finished)
-        logger.info('Player initialize finished.')
-
-    def shutdown(self):
-        self._mpv.terminate()
-
-    def play(self, url, video=True):
-        # NOTE - API DESGIN: we should return None, see
-        # QMediaPlayer API reference for more details.
-
-        logger.debug("Player will play: '%s'", url)
-
-        if video:
-            # FIXME: for some property, we need to set via setattr, however,
-            #  some need to be set via _mpv_set_property_string
-            self._mpv.handle.vid = b'auto'
-            # it seems that ytdl will auto choose the default format
-            #  if we set ytdl-format to ''
-            _mpv_set_property_string(self._mpv.handle, b'ytdl-format', b'')
-        else:
-            # set vid to no and ytdl-format to bestaudio/best
-            # see https://mpv.io/manual/stable/#options-vid for more details
-            self._mpv.handle.vid = b'no'
-            _mpv_set_property_string(self._mpv.handle, b'ytdl-format', b'bestaudio/best')
-
-        # Clear playlist before play next song,
-        # otherwise, mpv will seek to the last position and play.
-        self._mpv.playlist_clear()
-        self._mpv.play(url)
-        self._mpv.pause = False
-        self.state = State.playing
-        self._current_url = url
-        self.media_changed.emit(url)
-
-    def play_song(self, song):
-        """播放指定歌曲
-
-        如果目标歌曲与当前歌曲不相同，则修改播放列表当前歌曲，
-        播放列表会发出 song_changed 信号，player 监听到信号后调用 play 方法，
-        到那时才会真正的播放新的歌曲。如果和当前播放歌曲相同，则忽略。
-
-        .. note::
-
-            调用方不应该直接调用 playlist.current_song = song 来切换歌曲
-        """
-        if song is not None and song == self.current_song:
-            logger.warning('The song is already under playing.')
-        else:
-            self._playlist.current_song = song
-
-    def play_next(self):
-        """播放下一首歌曲
-
-        .. note::
-
-            这里不能使用 ``play_song(playlist.next_song)`` 方法来切换歌曲，
-            ``play_song`` 和 ``playlist.current_song = song`` 是有区别的。
-        """
-        self.playlist.current_song = self.playlist.next_song
-
-    def play_previous(self):
-        self.playlist.current_song = self.playlist.previous_song
-
-    def replay(self):
-        self.playlist.current_song = self.current_song
-
-    def resume(self):
-        self._mpv.pause = False
-        self.state = State.playing
-
-    def pause(self):
-        self._mpv.pause = True
-        self.state = State.paused
-
-    def toggle(self):
-        self._mpv.pause = not self._mpv.pause
-        if self._mpv.pause:
-            self.state = State.paused
-        else:
-            self.state = State.playing
-
-    def stop(self):
-        self._mpv.pause = True
-        self.state = State.stopped
-        self._current_url = None
-        self._mpv.playlist_clear()
-        logger.info('Player stopped.')
-
-    @property
-    def position(self):
-        return self._position
-
-    @position.setter
-    def position(self, position):
-        self._mpv.seek(position, reference='absolute')
-        self._position = position
-
-    @AbstractPlayer.volume.setter
-    def volume(self, value):
-        super(MpvPlayer, MpvPlayer).volume.__set__(self, value)
-        self._mpv.volume = self.volume
-
-    @property
-    def video_format(self):
-        self._video_format
-
-    @video_format.setter
-    def video_format(self, vformat):
-        self._video_format = vformat
-        self.video_format_changed.emit(vformat)
-
-    def _on_position_changed(self, position):
-        self._position = position
-        self.position_changed.emit(position)
-
-    def _on_duration_changed(self, duration):
-        """listening to mpv duration change event"""
-        logger.debug('Player receive duration changed signal')
-        self.duration = duration
-
-    def _on_video_format_changed(self, vformat):
-        self.video_format = vformat
-
-    def _on_song_changed(self, song):
-        """播放列表 current_song 发生变化后的回调
-
-        判断变化后的歌曲是否有效的，有效则播放，否则将它标记为无效歌曲。
-        如果变化后的歌曲是 None，则停止播放。
-        """
-        if song is not None:
-            if song.url:
-                self.play(song.url)
-            else:
-                self._playlist.mark_as_bad(song)
-                self.play_next()
-        else:
-            self.stop()
-
-    def _on_event(self, event):
-        if event['event_id'] == MpvEventID.END_FILE:
-            reason = event['event']['reason']
-            logger.debug('Current song finished. reason: %d' % reason)
-            if self.state != State.stopped and reason != MpvEventEndFile.ABORTED:
-                self.song_finished.emit()
-
-    def _on_song_finished(self):
-        if self._playlist.playback_mode == PlaybackMode.one_loop:
-            self.replay()
-        else:
-            self.play_next()
-
-    def __log_handler(self, loglevel, component, message):
-        print('[{}] {}: {}'.format(loglevel, component, message))
+# FIXME: remove this when no one import MpvPlayer from here
+from fuocore.mpvplayer import MpvPlayer

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from unittest import TestCase, mock
 
 from fuocore.models import Model, BaseModel, display_property
-from fuocore.models import Media
+from fuocore.models import MultiQualityMixin, Media
 
 
 class FakeProvider:
@@ -89,24 +89,25 @@ class TestDisplayProperty(TestCase):
         self.assertEqual(a1.a_display, '')
         self.assertEqual(a2.a_display, 'a2')
 
-class TestMedia(TestCase):
-    @mock.patch.object(Media, 'list_q')
-    @mock.patch.object(Media, 'get_url')
+class TestMultiQuality(TestCase):
+
+    @mock.patch.object(MultiQualityMixin, 'list_q')
+    @mock.patch.object(MultiQualityMixin, 'get_url')
     def test_select_url(self, mock_get_url, mock_list_q):
-        media = Media()
+        model = MultiQualityMixin()
 
         mock_list_q.return_value=Media.Q.list()
-        media.select_url(Media.Q.hd)
+        model.select_url(Media.Q.hd)
         mock_get_url.assert_called_with(Media.Q.hd)
 
         mock_list_q.return_value=[Media.Q.ld, Media.Q.sq]
-        media.select_url(Media.Q.hd)
+        model.select_url(Media.Q.hd)
         mock_get_url.assert_called_with(Media.Q.sq)
 
         mock_list_q.return_value=[Media.Q.ld, Media.Q.sq]
-        media.select_url(Media.Q.hd, s=Media.S.downup)
+        model.select_url(Media.Q.hd, s=Media.S.downup)
         mock_get_url.assert_called_with(Media.Q.ld)
 
-    @mock.patch.object(Media, 'list_q', return_value=[])
+    @mock.patch.object(MultiQualityMixin, 'list_q', return_value=[])
     def test_select_url_when_no_valid_quality(self, mock_list_q):
-        self.assertIsNone(Media().select_url(Media.Q.ld))
+        self.assertIsNone(MultiQualityMixin().select_url(Media.Q.ld))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,7 +2,6 @@ from collections import namedtuple
 from unittest import TestCase, mock
 
 from fuocore.models import Model, BaseModel, display_property
-from fuocore.models import MultiQualityMixin, Media
 
 
 class FakeProvider:
@@ -88,26 +87,3 @@ class TestDisplayProperty(TestCase):
         a2.a_display = 'a2'
         self.assertEqual(a1.a_display, '')
         self.assertEqual(a2.a_display, 'a2')
-
-class TestMultiQuality(TestCase):
-
-    @mock.patch.object(MultiQualityMixin, 'list_q')
-    @mock.patch.object(MultiQualityMixin, 'get_url')
-    def test_select_url(self, mock_get_url, mock_list_q):
-        model = MultiQualityMixin()
-
-        mock_list_q.return_value=Media.Q.list()
-        model.select_url(Media.Q.hd)
-        mock_get_url.assert_called_with(Media.Q.hd)
-
-        mock_list_q.return_value=[Media.Q.ld, Media.Q.sq]
-        model.select_url(Media.Q.hd)
-        mock_get_url.assert_called_with(Media.Q.sq)
-
-        mock_list_q.return_value=[Media.Q.ld, Media.Q.sq]
-        model.select_url(Media.Q.hd, s=Media.S.downup)
-        mock_get_url.assert_called_with(Media.Q.ld)
-
-    @mock.patch.object(MultiQualityMixin, 'list_q', return_value=[])
-    def test_select_url_when_no_valid_quality(self, mock_list_q):
-        self.assertIsNone(MultiQualityMixin().select_url(Media.Q.ld))

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -14,8 +14,15 @@ class FakeSongModel:  # pylint: disable=all
     pass
 
 
+class Meta:
+    support_multi_quality = True
+
+
 class FakeValidSongModel:
+    meta = Meta
     url = MP3_URL
+    def select_url(self, _):
+        return MP3_URL, _
 
 
 class TestPlayer(TestCase):


### PR DESCRIPTION
A song can associate with multiple **`media`**, when the player play a song, the player can choose a media by policy set by user(temporarily not implemented). We use the policy(`hd><`) by default. 

**breakchange**

- rewrite the `fuocore.models.Media class` and rename as `fuocore.media.Media`. The old version fuo-netease should be broken.